### PR TITLE
Fix runtime crashes on FreeBSD

### DIFF
--- a/src/Socket.h
+++ b/src/Socket.h
@@ -145,7 +145,13 @@ class Socket
             ~HostAddr()
             {
                 if(lookup)
-                    freeaddrinfo(addr);
+                {
+                    if(addr)
+                    {
+                        freeaddrinfo(addr);
+                        addr = NULL;
+                    }
+                }
                 else
                 {
                     free(addr->ai_addr);
@@ -157,7 +163,11 @@ class Socket
             // set
             void UpdateAddr()
             {
-                freeaddrinfo(addr);
+                if(addr)
+                {
+                    freeaddrinfo(addr);
+                    addr = NULL;
+                }
 
                 // do not use addr resolution for localhost
                 lookup = (host != "localhost");
@@ -174,7 +184,11 @@ class Socket
                     else
                         hints.ai_family = AF_INET;
 
-                    getaddrinfo(host.c_str(), port.c_str(), &hints, &addr);
+                    int error = getaddrinfo(host.c_str(), port.c_str(), &hints, &addr);
+                    if(error != 0)
+                    {
+                        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(error));
+                    }
                 }
                 else // fill with loopback
                 {


### PR DESCRIPTION
- FreeBSD doesn't like freeaddrinfo(NULL), plaster over this bug
- print the error from getaddrinfo for easier debugging
- don't pass in AI_ALL, while the flag is defined in FreeBSD's
  include/netdb.h, the call to getaddrinfo(3) will return an error when
  it is set.

This fixes issue #171