### PR TITLE
IWYU: need to include stdarg.h for definition of va_list

### DIFF
--- a/src/Log.h
+++ b/src/Log.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Singleton.h"
+#include <cstdarg>
 #include <cstdio>
 
 /// Log Klasse.


### PR DESCRIPTION
This fixes the build on FreeBSD with gcc 4.8