### PR TITLE
Implement Serialize/Deserialize for messages

### DIFF
--- a/src/Message.h
+++ b/src/Message.h
@@ -23,19 +23,20 @@
 
 class MessageInterface;
 class Socket;
+class Serializer;
 
-class Message : public Serializer
+class Message
 {
+    unsigned short id_;
     public:
         /// Konstruktor von @p Message.
         Message(unsigned short id) : id_(id) {}
-        /// Konstruktor, um Message aus vorhandenem Datenblock heraus zu erstellen
-        Message(const unsigned id, const unsigned char* const data, const unsigned length) : Serializer(data, length), id_(id) {}
+        virtual ~Message(){}
 
-        virtual unsigned short getId() const { return id_; }
-        bool send(Socket& sock);
+        virtual void Serialize(Serializer& ser) const{}
+        virtual void Deserialize(Serializer& ser){}
 
-        static Message* recv(Socket& sock, int& error, bool wait, Message * (*createfunction)(unsigned short));
+        unsigned short getId() const { return id_; }
         static Message* create_base(unsigned short id);
 
         virtual Message* create(unsigned short id) const { return create_base(id); }
@@ -44,7 +45,7 @@ class Message : public Serializer
         virtual void run(MessageInterface* callback, unsigned int id) = 0;
 
     protected:
-        Message(const Message& other): Serializer(other), id_(other.id_)
+        Message(const Message& other): id_(other.id_)
         {}
 
         Message& operator=(const Message& other)
@@ -52,17 +53,10 @@ class Message : public Serializer
             if(this == &other)
                 return *this;
 
-            Serializer::operator =(other);
             id_ = other.id_;
 
             return *this;
         }
-
-    private:
-        int recv(Socket& sock, unsigned int length);
-
-    protected:
-        unsigned short id_;
 };
 
 #endif //!MESSAGE_H_INCLUDED

--- a/src/MessageHandler.cpp
+++ b/src/MessageHandler.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#include "libUtilDefines.h"
+#include "MessageHandler.h"
+#include "Message.h"
+#include "Socket.h"
+#include "SocketSet.h"
+#include "Log.h"
+#include "MyTime.h"
+
+int MessageHandler::send(Socket& sock, const Message& msg)
+{
+    Serializer ser;
+    ser.PushUnsignedShort(0); // Id
+    ser.PushSignedInt(0); // Placeholder for length
+    const unsigned headerSize = ser.GetLength();
+    msg.Serialize(ser);
+
+    if(ser.GetLength() > 64 * 1024) /// 64KB, ACHTUNG: IPV4 garantiert nur maximal 576!!
+    {
+        LOG.lprintf("BIG OOPS! Message with length %u exceeds maximum of %d!\n", ser.GetLength(), 64 * 1024);
+        return -1;
+    }
+
+    unsigned char* data = ser.GetDataWritable(ser.GetLength());
+    *reinterpret_cast<int*>(data) = msg.getId();
+    *reinterpret_cast<int*>(data + sizeof(unsigned short)) = ser.GetLength() - headerSize;
+
+    if(ser.GetLength() != (unsigned int)sock.Send(data, ser.GetLength()))
+        return -1;
+    else
+        return ser.GetLength();
+}
+
+Message* MessageHandler::recv(Socket& sock, int& error, bool wait)
+{
+    error = -1;
+
+    unser_time_t startTime = TIME.CurrentTick();
+
+    while(true)
+    {
+        // Warten wir schon 15s auf Antwort?
+        if(wait && TIME.CurrentTick() - startTime > 15000)
+            wait = false;
+
+        SocketSet set;
+        // Socket hinzufgen
+        set.Add(sock);
+
+        // liegen Daten an?
+        int retval = set.Select(0, 0);
+
+        if(retval <= 0)
+        {
+            if(wait)
+                continue;
+
+            if(retval != -1)
+                error = 0;
+
+            return NULL;
+        }
+
+        // liegen diese Daten an unserem Socket, bzw wieviele Bytes liegen an?
+        unsigned int received;
+        if(!set.InSet(sock) || sock.BytesWaiting(&received) != 0)
+        {
+            if(wait)
+                continue;
+
+            error = 1;
+            return NULL;
+        }
+
+        // socket ist geschlossen worden
+        if(received == 0)
+            return NULL;
+
+        // haben wir schon eine vollständige nachricht? (kleinste nachricht: 6 bytes)
+        if(received < 6)
+        {
+            if(wait)
+                continue;
+
+            error = 2;
+            return NULL;
+        }
+        break;
+    }
+
+    char header[6];
+    unsigned short* id = (unsigned short*)&header[0];
+    int* length = (int*)&header[2];
+
+    // block empfangen
+    int headerSize = sizeof(header);
+    int read = sock.Recv(header, headerSize, false);
+    if(read != headerSize)
+    {
+        LOG.write("recv: block: only got %d bytes instead of %d, waiting for next try\n", read, headerSize);
+        if(read != -1)
+            error = 3;
+
+        return NULL;
+    }
+
+    if(length < 0)
+        throw std::runtime_error("Integer overflow during recv of message");
+
+    read = sock.BytesWaiting();
+
+    static unsigned blocktimeout = 0;
+    if(read < *length + headerSize)
+    {
+        ++blocktimeout;
+        LOG.write("recv: block-waiting: not enough input (%d/%d) for message (0x%04X), waiting for next try\n", read, *length + headerSize, *id);
+        if(blocktimeout < 120 && read != -1)
+            error = 4;
+
+        return NULL;
+    }
+    blocktimeout = 0;
+
+    // Block nochmals abrufen (um ihn aus dem Cache zu entfernen)
+    read = sock.Recv(header, headerSize);
+    if(read != headerSize)
+    {
+        LOG.lprintf("recv: id,length: only got %d bytes instead of %d\n", read, 2);
+        return NULL;
+    }
+
+    Serializer ser;
+    if(*length)
+    {
+        read = sock.Recv(ser.GetDataWritable(*length), *length);
+        if(read < *length)
+        {
+            LOG.lprintf("recv: data: only got %d bytes instead of %d\n", read, *length);
+            return NULL;
+        }
+        ser.SetLength(*length);
+    }
+
+    Message* msg = createMsg(*id);
+    if(!msg)
+        return NULL;
+
+    msg->Deserialize(ser);
+
+    return msg;
+}

--- a/src/MessageHandler.h
+++ b/src/MessageHandler.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2005 - 2015 Settlers Freaks (sf-team at siedler25.org)
+//
+// This file is part of Return To The Roots.
+//
+// Return To The Roots is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Return To The Roots is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Return To The Roots. If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MessageHandler_h__
+#define MessageHandler_h__
+
+class Message;
+class Socket;
+
+typedef Message* (*CreateMsgFunction)(unsigned short);
+
+class MessageHandler
+{
+    CreateMsgFunction createMsg;
+
+public:
+    MessageHandler(CreateMsgFunction createMsg): createMsg(createMsg) {}
+
+    /// Sends that message. Returns number of bytes submitted (-1 for failure)
+    static int send(Socket& sock, const Message& msg);
+    /// Receives a message. Returns NULL on error, or if nothing is available
+    /// Sets error if NULL returned: -1 = Fatal Error, 0 = socket busy, 1 = No msg available, 2 = incomplete, 3 = Header-Error, 4 = data incomplete
+    /// If wait is true, this blocks until a message is received or timeout is reached
+    Message* recv(Socket& sock, int& error, bool wait);
+};
+
+
+#endif // MessageHandler_h__

--- a/src/Messages.h
+++ b/src/Messages.h
@@ -22,7 +22,6 @@
 #include "Message.h"
 #include "MessageInterface.h"
 #include "Protocol.h"
-#include "Log.h"
 
 /*
  * das Klassenkommentar ist alles Client-Sicht, für Server-Sicht ist alles andersrum
@@ -39,14 +38,9 @@
 class Message_Null : public Message
 {
     public:
-        Message_Null(void) : Message(NMS_NULL_MSG) { }
-        Message_Null(bool reserved) : Message(NMS_NULL_MSG)
-        {
-            LOG.write(">>> NMS_NULL_MSG\n");
-        }
+        Message_Null() : Message(NMS_NULL_MSG) { }
         void run(MessageInterface* callback, unsigned int id)
         {
-            LOG.write("<<< NMS_NULL_MSG\n");
             callback->OnNMSNull(id);
         }
 };
@@ -57,14 +51,9 @@ class Message_Null : public Message
 class Message_Dead : public Message
 {
     public:
-        Message_Dead(void) : Message(NMS_DEAD_MSG) { }
-        Message_Dead(bool reserved) : Message(NMS_DEAD_MSG)
-        {
-            LOG.write(">>> NMS_DEAD_MSG\n");
-        }
+        Message_Dead() : Message(NMS_DEAD_MSG) { }
         void run(MessageInterface* callback, unsigned int id)
         {
-            LOG.write("<<< NMS_DEAD_MSG\n");
             callback->OnNMSDead(id);
         }
 };

--- a/src/SerializableArray.h
+++ b/src/SerializableArray.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "Message.h"
+#include "Serializer.h"
 #include <vector>
 #include <algorithm>
 
@@ -39,6 +39,8 @@ class SerializableArray
          */
         SerializableArray(void)
         {}
+
+        template <typename T> friend class SerializableArray;
 
         template<class T>
         SerializableArray(const SerializableArray<T> &other)
@@ -107,15 +109,12 @@ class SerializableArray
          *
          *  @author FloSoft
          */
-        inline void serialize(Message* msg) const
+        inline void serialize(Serializer& ser) const
         {
-            unsigned int count = elements.size();
-
-            if(msg)
-                msg->PushUnsignedInt(count);
+            ser.PushUnsignedInt(elements.size());
 
             for(typename std::vector<Type>::const_iterator it = elements.begin(); it!=elements.end(); ++it)
-                it->serialize(msg);
+                it->serialize(ser);
         }
 
         ///////////////////////////////////////////////////////////////////////////////
@@ -128,21 +127,14 @@ class SerializableArray
          *
          *  @author FloSoft
          */
-        inline void deserialize(Message* msg)
+        inline void deserialize(Serializer& ser)
         {
-            if(!msg)
-                return;
-
-            unsigned int count = msg->PopUnsignedInt();
-
             clear();
-
+            unsigned count = ser.PopUnsignedInt();
             elements.reserve(count);
 
             for(unsigned int i = 0; i < count; ++i)
-            {
-                elements.push_back(Type(i, msg));
-            }
+                elements.push_back(Type(i, ser));
         }
 
         ///////////////////////////////////////////////////////////////////////////////

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -41,8 +41,7 @@ void Serializer::ReadFromFile(BinaryFile& file)
 
     unsigned buffer_size;
     buffer_size = file.ReadUnsignedInt();
-    EnsureSize(buffer_size);
-    file.ReadRawData(GetDataWritable(), buffer_size);
+    file.ReadRawData(GetDataWritable(buffer_size), buffer_size);
     SetLength(buffer_size);
 }
 

--- a/src/Serializer.h
+++ b/src/Serializer.h
@@ -71,9 +71,29 @@ class Serializer
             return length_;
         }
 
+        /// Schreibzugriff auf die Länge
+        void SetLength(const unsigned int length)
+        {
+            EnsureSize(length);
+            this->length_ = length;
+        }
+
+        unsigned GetBytesLeft() const
+        {
+            assert(pos_ < length_);
+            return length_ - pos_;
+        }
+
         /// Zugriff auf die Rohdaten
         const unsigned char* GetData(void) const
         {
+            return data_.data();
+        }
+
+        /// Schreibzugriff auf die Rohdaten
+        unsigned char* GetDataWritable(unsigned length)
+        {
+            EnsureSize(length);
             return data_.data();
         }
 
@@ -262,18 +282,6 @@ class Serializer
             this->length_ += sizeof(T);
         }
 
-        /// Schreibzugriff auf die Rohdaten
-        unsigned char* GetDataWritable(void)
-        {
-            return data_.data();
-        }
-
-        /// Schreibzugriff auf die Länge
-        void SetLength(const unsigned int length)
-        {
-            this->length_ = length;
-        }
-
         /// Erweitert ggf. Speicher um add_length
         inline void ExtendMemory(const unsigned add_length)
         {
@@ -283,8 +291,11 @@ class Serializer
         /// Makes sure the internal buffer is at least length bytes long
         inline void EnsureSize(const unsigned length)
         {
-            data_.reserve(length);
-            data_.resize(data_.capacity());
+            if(data_.size() < length)
+            {
+                data_.reserve(length);
+                data_.resize(data_.capacity());
+            }
         }
 
     private:


### PR DESCRIPTION
Implement Serialize/Deserialize for messages to keep their state consistent

This avoids wondering, what values the message have. They were used in 2 ways: Serializer and data storage with also some double functionality per message.
This PR makes them pure storage and handlers and adds appropriate Serialize/Deserialize functions

Also sending/receiving is factored out into a message handler. This can be extended to handle partially received messages (that should not happen, but it is possible...)

@Flow86 Can I merge this?