### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/getExecutablePath.cpp
+++ b/src/getExecutablePath.cpp
@@ -96,7 +96,7 @@ std::string getExecutablePath()
 
 std::string getExecutablePath()
 {
-    std::array<int, 4> mib = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    int mib = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
     std::vector<char> buf(1024, 0);
     size_t size = buf.size();
     if(sysctl(mib, 4, &buf[0], &size, nullptr, 0) != 0)


### PR DESCRIPTION
When compiling on FreeBSD, I get:
```
/tmp/usr/ports/games/returntotheroots/work/s25client-be5efd4/external/libutil/src/getExecutablePath.cpp:103:8: error: no matching function for call to 'sysctl'
    if(sysctl(mib, 4, &buf[0], &size, nullptr, 0) != 0)
       ^~~~~~
/usr/include/sys/sysctl.h:1062:5: note: candidate function not viable: no known conversion from 'std::array<int, 4>' to 'const int *' for 1st argument
int     sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
        ^
1 error generated.
```