### PR TITLE
Add arm64 to macOS platforms

### DIFF
--- a/cmake/DetectOsXArchs.cmake
+++ b/cmake/DetectOsXArchs.cmake
@@ -58,7 +58,7 @@ function(detect_osx_archs)
         set(cmdStdOut x86_64)
     endif()
 
-    set(OSX_POSSIBLE_ARCHS x86_64 i386 i686 ppc)
+    set(OSX_POSSIBLE_ARCHS x86_64 i386 i686 ppc arm64)
     set(OSX_DETECTED_ARCHS)
     foreach(arch IN LISTS OSX_POSSIBLE_ARCHS)
         if(cmdStdOut MATCHES "${arch}")


### PR DESCRIPTION
Apple Silicon (arm64) support/detection is missing from current macOS platform detection.

This should fix https://github.com/Return-To-The-Roots/s25client/issues/1504.

Note that this change will still result in a build failure as precompiled libraries at external/dev-tools/ are missing arm64 symbols.

But at least CMake configuration step succeeds.