### PR TITLE
Extend bitset functionallity

### DIFF
--- a/libs/common/include/s25util/enumUtils.h
+++ b/libs/common/include/s25util/enumUtils.h
@@ -6,16 +6,47 @@
 
 #include <type_traits>
 
+template<typename Enum>
+struct IsBitset : std::false_type
+{};
+
+template<typename Enum>
+constexpr bool IsValidBitset = IsBitset<Enum>::value && std::is_unsigned<std::underlying_type_t<Enum>>::value;
+
+template<typename Enum>
+using require_validBitset = std::enable_if_t<IsValidBitset<Enum>>;
+
+template<typename Enum, typename = require_validBitset<Enum>>
+constexpr auto operator&(Enum lhs, Enum rhs) noexcept
+{
+    using Int = std::underlying_type_t<Enum>;
+    return Enum(static_cast<Int>(lhs) & static_cast<Int>(rhs));
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+constexpr auto operator|(Enum lhs, Enum rhs) noexcept
+{
+    using Int = std::underlying_type_t<Enum>;
+    return Enum(static_cast<Int>(lhs) | static_cast<Int>(rhs));
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+constexpr auto operator&=(Enum& lhs, Enum rhs) noexcept
+{
+    return lhs = lhs & rhs;
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+constexpr auto operator|=(Enum& lhs, Enum rhs) noexcept
+{
+    return lhs = lhs | rhs;
+}
+
 /// Makes a strongly typed enum usable as a bitset
-#define MAKE_BITSET_STRONG(Type)                                              \
-    inline auto operator&(Type lhs, Type rhs)                                 \
-    {                                                                         \
-        return Type(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs)); \
-    }                                                                         \
-    inline auto operator|(Type lhs, Type rhs)                                 \
-    {                                                                         \
-        return Type(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs)); \
-    }                                                                         \
-    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                          \
-    static_assert(std::is_unsigned<std::underlying_type_t<Type>>::value,      \
+#define MAKE_BITSET_STRONG(Type)                                         \
+    template<>                                                           \
+    struct IsBitset<Type> : std::true_type                               \
+    {};                                                                  \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                     \
+    static_assert(std::is_unsigned<std::underlying_type_t<Type>>::value, \
                   #Type " must use unsigned type as the underlying type")

--- a/libs/common/include/s25util/enumUtils.h
+++ b/libs/common/include/s25util/enumUtils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <boost/config.hpp>
 #include <type_traits>
 
 template<typename Enum>
@@ -31,16 +32,44 @@ constexpr auto operator|(Enum lhs, Enum rhs) noexcept
 }
 
 template<typename Enum, typename = require_validBitset<Enum>>
-constexpr auto operator&=(Enum& lhs, Enum rhs) noexcept
+constexpr Enum& operator&=(Enum& lhs, Enum rhs) noexcept
 {
     return lhs = lhs & rhs;
 }
 
 template<typename Enum, typename = require_validBitset<Enum>>
-constexpr auto operator|=(Enum& lhs, Enum rhs) noexcept
+constexpr Enum& operator|=(Enum& lhs, Enum rhs) noexcept
 {
     return lhs = lhs | rhs;
 }
+
+namespace bitset {
+template<typename Enum, typename = require_validBitset<Enum>>
+BOOST_ATTRIBUTE_NODISCARD constexpr Enum clear(const Enum val, const Enum flag)
+{
+    using Int = std::underlying_type_t<Enum>;
+    return val & Enum(~static_cast<const Int>(flag));
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+BOOST_ATTRIBUTE_NODISCARD constexpr Enum set(const Enum val, const Enum flag, const bool state = true)
+{
+    return state ? (val | flag) : clear(val, flag);
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+BOOST_ATTRIBUTE_NODISCARD constexpr Enum toggle(const Enum val, const Enum flag)
+{
+    using Int = std::underlying_type_t<Enum>;
+    return Enum(static_cast<const Int>(val) ^ static_cast<const Int>(flag));
+}
+
+template<typename Enum, typename = require_validBitset<Enum>>
+BOOST_ATTRIBUTE_NODISCARD constexpr bool isSet(const Enum val, const Enum flag)
+{
+    return (val & flag) == flag;
+}
+} // namespace bitset
 
 /// Makes a strongly typed enum usable as a bitset
 #define MAKE_BITSET_STRONG(Type)                                         \

--- a/libs/common/include/s25util/enumUtils.h
+++ b/libs/common/include/s25util/enumUtils.h
@@ -12,10 +12,10 @@ struct IsBitset : std::false_type
 {};
 
 template<typename Enum>
-constexpr bool IsValidBitset = IsBitset<Enum>::value && std::is_unsigned<std::underlying_type_t<Enum>>::value;
+constexpr bool IsValidBitset_v = IsBitset<Enum>::value && std::is_unsigned<std::underlying_type_t<Enum>>::value;
 
 template<typename Enum>
-using require_validBitset = std::enable_if_t<IsValidBitset<Enum>>;
+using require_validBitset = std::enable_if_t<IsValidBitset_v<Enum>>;
 
 template<typename Enum, typename = require_validBitset<Enum>>
 constexpr auto operator&(Enum lhs, Enum rhs) noexcept

--- a/tests/testEnumUtils.cpp
+++ b/tests/testEnumUtils.cpp
@@ -38,17 +38,17 @@ BOOST_AUTO_TEST_CASE(Operators)
     {
         Bitset b{};
         b = b | Bitset::A;
-        BOOST_TEST(static_cast<unsigned>(b) == 0x01u);
+        BOOST_TEST(static_cast<unsigned>(b) == 0b001u);
         b |= Bitset::B;
-        BOOST_TEST(static_cast<unsigned>(b) == 0x03u);
+        BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
     }
 
     {
         Bitset b = Bitset::A | Bitset::B | Bitset::C;
         b = b & (Bitset::A | Bitset::B);
-        BOOST_TEST(static_cast<unsigned>(b) == 0x03u);
+        BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
         b &= Bitset::B;
-        BOOST_TEST(static_cast<unsigned>(b) == 0x02u);
+        BOOST_TEST(static_cast<unsigned>(b) == 0b010u);
     }
 }
 
@@ -61,19 +61,19 @@ BOOST_AUTO_TEST_CASE(UtilityFunctions)
     BOOST_TEST(!bitset::isSet(b, Bitset::B | Bitset::C));
 
     b = bitset::set(b, Bitset::B /*, true */);
-    BOOST_TEST(static_cast<unsigned>(b) == 0x07u);
+    BOOST_TEST(static_cast<unsigned>(b) == 0b111u);
 
     b = bitset::set(b, Bitset::B, false);
-    BOOST_TEST(static_cast<unsigned>(b) == 0x05u);
+    BOOST_TEST(static_cast<unsigned>(b) == 0b101u);
 
     b = bitset::clear(b, Bitset::A);
-    BOOST_TEST(static_cast<unsigned>(b) == 0x04u);
+    BOOST_TEST(static_cast<unsigned>(b) == 0b100u);
 
     b = bitset::toggle(b, Bitset::A);
-    BOOST_TEST(static_cast<unsigned>(b) == 0x05u);
+    BOOST_TEST(static_cast<unsigned>(b) == 0b101u);
 
     b = bitset::toggle(b, Bitset::A | Bitset::B);
-    BOOST_TEST(static_cast<unsigned>(b) == 0x06u);
+    BOOST_TEST(static_cast<unsigned>(b) == 0b110u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/testEnumUtils.cpp
+++ b/tests/testEnumUtils.cpp
@@ -41,6 +41,8 @@ BOOST_AUTO_TEST_CASE(Operators)
         BOOST_TEST(static_cast<unsigned>(b) == 0b001u);
         b |= Bitset::B;
         BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
+	(b |= Bitset::A) = Bitset::C;
+	BOOST_CHECK(b == Bitset::C);
     }
 
     {
@@ -49,6 +51,8 @@ BOOST_AUTO_TEST_CASE(Operators)
         BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
         b &= Bitset::B;
         BOOST_TEST(static_cast<unsigned>(b) == 0b010u);
+	(b &= Bitset::A) = Bitset::C;
+	BOOST_CHECK(b == Bitset::C);
     }
 }
 

--- a/tests/testEnumUtils.cpp
+++ b/tests/testEnumUtils.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2005 - 2023 Settlers Freaks (sf-team at siedler25.org)
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "s25util/enumUtils.h"
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+
+enum class InvalidBitset : int
+{
+};
+template<>
+struct IsBitset<InvalidBitset> : std::true_type
+{};
+
+enum class Bitset : unsigned
+{
+    None,
+    A = 1 << 0,
+    B = 1 << 1,
+    C = 1 << 2
+};
+MAKE_BITSET_STRONG(Bitset);
+
+// Check type traits
+static_assert(IsBitset<InvalidBitset>::value);
+static_assert(!IsValidBitset<InvalidBitset>);
+
+static_assert(IsBitset<Bitset>::value);
+static_assert(IsValidBitset<Bitset>);
+
+BOOST_AUTO_TEST_SUITE(EnumUtils)
+
+BOOST_AUTO_TEST_CASE(Operators)
+{
+    BOOST_REQUIRE(static_cast<unsigned>(Bitset{}) == 0);
+
+    {
+        Bitset b{};
+        b = b | Bitset::A;
+        BOOST_TEST(static_cast<unsigned>(b) == 0x01u);
+        b |= Bitset::B;
+        BOOST_TEST(static_cast<unsigned>(b) == 0x03u);
+    }
+
+    {
+        Bitset b = Bitset::A | Bitset::B | Bitset::C;
+        b = b & (Bitset::A | Bitset::B);
+        BOOST_TEST(static_cast<unsigned>(b) == 0x03u);
+        b &= Bitset::B;
+        BOOST_TEST(static_cast<unsigned>(b) == 0x02u);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(UtilityFunctions)
+{
+    Bitset b = Bitset::A | Bitset::C;
+    BOOST_TEST(bitset::isSet(b, Bitset::A));
+    BOOST_TEST(bitset::isSet(b, Bitset::A | Bitset::C));
+    BOOST_TEST(!bitset::isSet(b, Bitset::B));
+    BOOST_TEST(!bitset::isSet(b, Bitset::B | Bitset::C));
+
+    b = bitset::set(b, Bitset::B /*, true */);
+    BOOST_TEST(static_cast<unsigned>(b) == 0x07u);
+
+    b = bitset::set(b, Bitset::B, false);
+    BOOST_TEST(static_cast<unsigned>(b) == 0x05u);
+
+    b = bitset::clear(b, Bitset::A);
+    BOOST_TEST(static_cast<unsigned>(b) == 0x04u);
+
+    b = bitset::toggle(b, Bitset::A);
+    BOOST_TEST(static_cast<unsigned>(b) == 0x05u);
+
+    b = bitset::toggle(b, Bitset::A | Bitset::B);
+    BOOST_TEST(static_cast<unsigned>(b) == 0x06u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/testEnumUtils.cpp
+++ b/tests/testEnumUtils.cpp
@@ -24,10 +24,10 @@ MAKE_BITSET_STRONG(Bitset);
 
 // Check type traits
 static_assert(IsBitset<InvalidBitset>::value);
-static_assert(!IsValidBitset<InvalidBitset>);
+static_assert(!IsValidBitset_v<InvalidBitset>);
 
 static_assert(IsBitset<Bitset>::value);
-static_assert(IsValidBitset<Bitset>);
+static_assert(IsValidBitset_v<Bitset>);
 
 BOOST_AUTO_TEST_SUITE(EnumUtils)
 


### PR DESCRIPTION
I went ahead with the PR anyway. (This is for https://github.com/Return-To-The-Roots/s25client/pull/1602.)

* Add trait-based opt-in.
* Replace macro-generated operators with template functions.
* Add more operator overloads.
* Add utility functions to set, clear, toggle, and query flags.
* Add unit tests.

I've introduced a local macro `ENUM_UTILS_NODISCARD` but think it might be useful to add `NODISCARD` or `RTTR_NODISCARD` globally. If so, where should I put it? A new file? `compile.h`, `macros.h`, `future.h`, ...