### PR TITLE
Fix formatting

### DIFF
--- a/tests/testEnumUtils.cpp
+++ b/tests/testEnumUtils.cpp
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_CASE(Operators)
         BOOST_TEST(static_cast<unsigned>(b) == 0b001u);
         b |= Bitset::B;
         BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
-	(b |= Bitset::A) = Bitset::C;
-	BOOST_CHECK(b == Bitset::C);
+        (b |= Bitset::A) = Bitset::C;
+        BOOST_CHECK(b == Bitset::C);
     }
 
     {
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(Operators)
         BOOST_TEST(static_cast<unsigned>(b) == 0b011u);
         b &= Bitset::B;
         BOOST_TEST(static_cast<unsigned>(b) == 0b010u);
-	(b &= Bitset::A) = Bitset::C;
-	BOOST_CHECK(b == Bitset::C);
+        (b &= Bitset::A) = Bitset::C;
+        BOOST_CHECK(b == Bitset::C);
     }
 }
 


### PR DESCRIPTION
Some tabs snuck in when I made last-minute changes using vim. Sorry about that.

I was missing [Refined Github](https://github.com/refined-github/refined-github), which I highly recommend. For the whitespace visualization alone:

![image](https://github.com/Return-To-The-Roots/libutil/assets/320854/64bd6306-70a8-4d2e-9f07-c6fcf994e0bc)
