### PR TITLE
Automatic fixes of clang-tidy warnings: readability-simplify-boolean-…

### DIFF
--- a/libs/common/include/s25util/BinaryFile.h
+++ b/libs/common/include/s25util/BinaryFile.h
@@ -56,7 +56,7 @@ public:
     void Flush();
     bool IsEndOfFile() const;
     /// Is file opened
-    bool IsOpen() const { return file ? true : false; }
+    bool IsOpen() const { return static_cast<bool>(file); }
 
     const boost::filesystem::path& getFilePath() const { return filePath_; }
 

--- a/libs/network/include/s25util/Socket.h
+++ b/libs/network/include/s25util/Socket.h
@@ -181,7 +181,7 @@ public:
     /// Returns true, if this is a broadcast socket (only meaningfull if it is valid)
     bool IsBroadcast() const { return isBroadcast; }
 
-    friend void swap(Socket& s1, Socket& s2)
+    friend void swap(Socket& s1, Socket& s2) noexcept
     {
         using std::swap;
         swap(s1.status_, s2.status_);

--- a/libs/network/src/LANDiscoveryClient.cpp
+++ b/libs/network/src/LANDiscoveryClient.cpp
@@ -55,5 +55,5 @@ void LANDiscoveryClient::Run()
 void LANDiscoveryClient::Refresh()
 {
     services.clear();
-    Broadcast(&request.data[0], sizeof(request));
+    Broadcast(request.data.data(), sizeof(request));
 }

--- a/libs/network/src/UPnP_Other.cpp
+++ b/libs/network/src/UPnP_Other.cpp
@@ -94,7 +94,7 @@ inline bool getValidIGD(const DeviceList& deviceList, Urls& urls, IGDdatas& data
 #if(MINIUPNPC_API_VERSION >= 18)
     return UPNP_GetValidIGD(deviceList, &urls, &data, &lanAddr[0], lanAddr.size(), NULL, 0) == 1;
 #else
-    return UPNP_GetValidIGD(deviceList, &urls, &data, &lanAddr[0], lanAddr.size()) == 1;
+    return UPNP_GetValidIGD(deviceList, &urls, &data, lanAddr.data(), lanAddr.size()) == 1;
 #endif
 }
 


### PR DESCRIPTION
…expr,modernize-type-traits,misc-unused-alias-decls,misc-unused-using-decls,modernize-use-auto,performance-inefficient-vector-operation,performance-move-const-arg,readability-container-size-empty,readability-redundant-member-init,performance-noexcept-swap,readability-redundant-inline-specifier,readability-container-data-pointer