### PR TITLE
add noexcept to prevent gcc15 error

### DIFF
--- a/libs/common/include/s25util/SerializableArray.h
+++ b/libs/common/include/s25util/SerializableArray.h
@@ -129,9 +129,9 @@ public:
     void resize(const unsigned count) { return elements.resize(count); }
 
     iterator begin() { return elements.begin(); }
-    const_iterator begin() const { return elements.begin(); }
+    const_iterator begin() const noexcept { return elements.begin(); }
     iterator end() { return elements.end(); }
-    const_iterator end() const { return elements.end(); }
+    const_iterator end() const noexcept { return elements.end(); }
 
 private:
     std::vector<Type> elements; /// Die Elemente


### PR DESCRIPTION
Currently when compiling with gcc15.1.1 without the noexcept changes, the compiler would exit with an error:


```make
In Datei, eingebunden von /usr/include/c++/15.1.1/string:55,
                 von /home/markus/Projekte/s25client/libs/s25main/controls/ctrlBaseText.h:7,
                 von /home/markus/Projekte/s25client/libs/s25main/TextFormatSetter.h:7,
                 von /home/markus/Projekte/s25client/libs/s25main/Window.h:10,
                 von /home/markus/Projekte/s25client/libs/s25main/desktops/Desktop.h:7,
                 von /home/markus/Projekte/s25client/libs/s25main/desktops/dskMenuBase.h:7,
                 von /home/markus/Projekte/s25client/libs/s25main/desktops/dskLobby.h:7,
                 von /home/markus/Projekte/s25client/libs/s25main/desktops/dskLobby.cpp:5:
/usr/include/c++/15.1.1/bits/range_access.h:66:46: Fehler: noexcept-Ausdruck wird wegen Aufruf von »SerializableArray<Type>::const_iterator SerializableArray<Type>::begin() const [with Type = LobbyServerInfo; const_iterator = std::vector<LobbyServerInfo, std::allocator<LobbyServerInfo> >::const_iterator]« zu »false« ausgewertet [-Werror=noexcept]
   66 |     begin(const _Container& __cont) noexcept(noexcept(__cont.begin()))
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~
In Datei, eingebunden von /home/markus/Projekte/s25client/external/liblobby/include/liblobby/LobbyPlayerList.h:11,
                 von /home/markus/Projekte/s25client/external/liblobby/include/liblobby/LobbyClient.h:10,
                 von /home/markus/Projekte/s25client/libs/s25main/desktops/dskLobby.cpp:22:
/home/markus/Projekte/s25client/external/libutil/libs/common/include/s25util/SerializableArray.h:132:20: Anmerkung: aber »SerializableArray<Type>::const_iterator SerializableArray<Type>::begin() const [with Type = LobbyServerInfo; const_iterator = std::vector<LobbyServerInfo, std::allocator<LobbyServerInfo> >::const_iterator]« wirft nicht; vielleicht sollte sie als »noexcept« deklariert werden
  132 |     const_iterator begin() const  { return elements.begin(); }
      |                    ^~~~~
/usr/include/c++/15.1.1/bits/range_access.h:90:44: Fehler: noexcept-Ausdruck wird wegen Aufruf von »SerializableArray<Type>::const_iterator SerializableArray<Type>::end() const [with Type = LobbyServerInfo; const_iterator = std::vector<LobbyServerInfo, std::allocator<LobbyServerInfo> >::const_iterator]« zu »false« ausgewertet [-Werror=noexcept]
   90 |     end(const _Container& __cont) noexcept(noexcept(__cont.end()))
      |                                            ^~~~~~~~~~~~~~~~~~~~~~
/home/markus/Projekte/s25client/external/libutil/libs/common/include/s25util/SerializableArray.h:134:20: Anmerkung: aber »SerializableArray<Type>::const_iterator SerializableArray<Type>::end() const [with Type = LobbyServerInfo; const_iterator = std::vector<LobbyServerInfo, std::allocator<LobbyServerInfo> >::const_iterator]« wirft nicht; vielleicht sollte sie als »noexcept« deklariert werden
  134 |     const_iterator end() const { return elements.end(); }
      |                    ^~~
cc1plus: Alle Warnungen werden als Fehler behandelt
make[2]: *** [libs/s25main/CMakeFiles/s25Main.dir/build.make:1913: libs/s25main/CMakeFiles/s25Main.dir/desktops/dskLobby.cpp.o] Fehler 1
make[2]: *** Es wird auf noch nicht beendete Prozesse gewartet …
make[1]: *** [CMakeFiles/Makefile2:2044: libs/s25main/CMakeFiles/s25Main.dir/all] Fehler 2
make: *** [Makefile:166: all] Fehler 2
