### PR TITLE
Suppress Clang22 C2y extension errors

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -107,6 +107,10 @@ function(enable_warnings target)
       # To many false positives until clang 10 fixed them
       check_and_add_warnings(TARGET ${target} VISIBILITY ${visibility} CXX -Wno-range-loop-analysis)
     endif()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+      # Clang 22 will throw errors since __COUNTER__ will be added to C2y
+      check_and_add_warnings(TARGET ${target} VISIBILITY ${visibility} CXX -Wno-c2y-extensions)
+    endif()
     # Not used:
       #-Wpadded
       #-Wstack-protector


### PR DESCRIPTION
The `__COUNTER__` macro will be added to [C2Y](https://en.wikipedia.org/wiki/C2Y_(C_standard_revision)#Preprocessor) and clang throws errors when using an older standard

```
s25client/tests/common/testContainerUtils.cpp:14:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
   14 | BOOST_AUTO_TEST_SUITE(ContainerUtils)
      | ^
/usr/include/boost/test/unit_test_suite.hpp:75:9: note: expanded from macro 'BOOST_AUTO_TEST_SUITE'
   75 |         BOOST_AUTO_TEST_SUITE_NO_DECOR,                                 \
      |         ^
s25client/tests/common/testContainerUtils.cpp:18:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
   18 | BOOST_AUTO_TEST_CASE(MakeUniqueStable)
      | ^
/usr/include/boost/test/unit_test_suite.hpp:212:9: note: expanded from macro 'BOOST_AUTO_TEST_CASE'
  212 |         BOOST_AUTO_TEST_CASE_NO_DECOR,                                  \
      |         ^
s25client/tests/common/testContainerUtils.cpp:46:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
   46 | BOOST_AUTO_TEST_CASE(MakeUnique)
      | ^
/usr/include/boost/test/unit_test_suite.hpp:212:9: note: expanded from macro 'BOOST_AUTO_TEST_CASE'
  212 |         BOOST_AUTO_TEST_CASE_NO_DECOR,                                  \
      |         ^
s25client/tests/common/testContainerUtils.cpp:74:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
   74 | BOOST_AUTO_TEST_CASE(IndexOf)
      | ^
/usr/include/boost/test/unit_test_suite.hpp:212:9: note: expanded from macro 'BOOST_AUTO_TEST_CASE'
  212 |         BOOST_AUTO_TEST_CASE_NO_DECOR,                                  \
      |         ^
...
```