### PR TITLE
Add reserved name handling and add user filename validation

### DIFF
--- a/libs/common/include/s25util/fileFuncs.h
+++ b/libs/common/include/s25util/fileFuncs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -6,12 +6,19 @@
 
 #include <string>
 
-/// Remove all invalid chars of a file or directory name. Result may be empty!
-/// --> bfs::portable_name will return true
+/// Sanitizes to a portable name. Appends '_' to Windows reserved device names. Result may be empty.
+/// --> bfs::portable_name will return true for non-empty results
 std::string makePortableName(const std::string& fileName);
-/// Remove all invalid chars so the name can be used for a file. Result may be empty!
-/// --> bfs::portable_file_name will return true
+/// Sanitizes to a portable filename. Result may be empty.
+/// --> bfs::portable_file_name will return true for non-empty results
 std::string makePortableFileName(const std::string& fileName);
-/// Remove all invalid chars so the name can be used for a directory. Result may be empty!
-/// --> bfs::portable_directory_name will return true
+/// Sanitizes to a portable directory name. Result may be empty.
+/// --> bfs::portable_directory_name will return true for non-empty results
 std::string makePortableDirName(const std::string& fileName);
+
+/// Returns true if c is valid in a user-provided filename.
+/// Rejects control characters and chars forbidden on Windows (< > : " / \ | ? *).
+bool isValidFileNameChar(char32_t c);
+/// Returns true if fileName is a valid user-provided filename.
+/// Rejects reserved device names, empty names, leading/trailing dots, and trailing spaces.
+bool isValidFileName(const std::string& fileName);

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem/path.hpp>
 #include <algorithm>
 #include <array>
+#include <string_view>
 
 namespace bfs = boost::filesystem;
 
@@ -99,9 +100,8 @@ bool isValidFileNameChar(char32_t c)
         return false;
     // Reject characters forbidden on Windows (the most restrictive platform),
     // which covers all restrictions on Linux, macOS, and Android as well.
-    if(c == '<' || c == '>' || c == ':' || c == '"' || c == '/' || c == '\\' || c == '|' || c == '?' || c == '*')
-        return false;
-    return true;
+    static constexpr std::u32string_view forbidden = U"<>:\"/\\|?*";
+    return forbidden.find(c) == std::u32string_view::npos;
 }
 
 bool isValidFileName(const std::string& fileName)

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -113,6 +113,11 @@ bool isValidFileName(const std::string& fileName)
     // the name the user typed and the file actually created on disk.
     if(fileName.back() == ' ')
         return false;
+    for(char c : fileName)
+    {
+        if(!isValidFileNameChar(static_cast<unsigned char>(c)))
+            return false;
+    }
     // On Windows 7 and earlier the device name is the part before the first dot — "nul.ini" is NUL thus forbidden.
     return !isReservedName(fileName.substr(0, fileName.find('.')));
 }

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -4,6 +4,7 @@
 
 #include "fileFuncs.h"
 #include "s25util/strAlgos.h"
+#include "s25util/utf8.h"
 #include <boost/filesystem/path.hpp>
 #include <algorithm>
 #include <array>
@@ -106,6 +107,8 @@ bool isValidFileNameChar(char32_t c)
 bool isValidFileName(const std::string& fileName)
 {
     if(fileName.empty())
+        return false;
+    if(s25util::utf8to32(fileName).size() > 255)
         return false;
     if(fileName.front() == '.' || fileName.back() == '.')
         return false;

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -108,17 +108,18 @@ bool isValidFileName(const std::string& fileName)
 {
     if(fileName.empty())
         return false;
-    if(s25util::utf8to32(fileName).size() > 255)
+    const auto asU32 = s25util::utf8to32(fileName);
+    if(asU32.size() > 255)
         return false;
-    if(fileName.front() == '.' || fileName.back() == '.')
+    if(asU32.front() == U'.' || asU32.back() == U'.')
         return false;
     // Windows silently strips trailing spaces, which would create a mismatch between
     // the name the user typed and the file actually created on disk.
-    if(fileName.back() == ' ')
+    if(asU32.back() == U' ')
         return false;
-    for(char c : fileName)
+    for(char32_t c : asU32)
     {
-        if(!isValidFileNameChar(static_cast<unsigned char>(c)))
+        if(!isValidFileNameChar(c))
             return false;
     }
     // On Windows 7 and earlier the device name is the part before the first dot — "nul.ini" is NUL thus forbidden.

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -106,11 +106,11 @@ bool isValidFileNameChar(char32_t c)
 
 bool isValidFileName(const std::string& fileName)
 {
-    if(fileName.empty())
+    if(fileName.empty() || !s25util::isValidUTF8(fileName))
+        return false;
+    if(fileName.size() > 255)
         return false;
     const auto asU32 = s25util::utf8to32(fileName);
-    if(asU32.size() > 255)
-        return false;
     if(asU32.front() == U'.' || asU32.back() == U'.')
         return false;
     // Windows silently strips trailing spaces, which would create a mismatch between

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -1,16 +1,30 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "fileFuncs.h"
+#include "s25util/strAlgos.h"
 #include <boost/filesystem/path.hpp>
+#include <algorithm>
+#include <array>
 
 namespace bfs = boost::filesystem;
+
+// Windows reserved device names
+static constexpr std::array reservedNames{"con",  "prn",  "aux",  "nul",  "com0", "com1", "com2", "com3",
+                                          "com4", "com5", "com6", "com7", "com8", "com9", "lpt0", "lpt1",
+                                          "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"};
+
+static bool isReservedName(const std::string& name)
+{
+    const std::string lower = s25util::toLower(name);
+    return std::find(reservedNames.begin(), reservedNames.end(), lower) != reservedNames.end();
+}
 
 std::string makePortableName(const std::string& fileName)
 {
     if(fileName.empty() || bfs::portable_name(fileName))
-        return fileName;
+        return isReservedName(fileName) ? fileName + '_' : fileName;
     std::string result;
     result.reserve(fileName.size());
     for(char c : fileName)
@@ -30,6 +44,8 @@ std::string makePortableName(const std::string& fileName)
         while(!result.empty() && result.back() == '.')
             result.erase(result.end() - 1);
     }
+    if(!result.empty() && isReservedName(result))
+        result += '_';
     assert(result.empty() || bfs::portable_name(result));
     return result;
 }
@@ -73,4 +89,30 @@ std::string makePortableDirName(const std::string& fileName)
     }
     assert(result.empty() || bfs::portable_directory_name(result));
     return result;
+}
+
+bool isValidFileNameChar(char32_t c)
+{
+    // Reject control characters
+    if(c <= 0x1F || c == 0x7F)
+        return false;
+    // Reject characters forbidden on Windows (the most restrictive platform),
+    // which covers all restrictions on Linux, macOS, and Android as well.
+    if(c == '<' || c == '>' || c == ':' || c == '"' || c == '/' || c == '\\' || c == '|' || c == '?' || c == '*')
+        return false;
+    return true;
+}
+
+bool isValidFileName(const std::string& fileName)
+{
+    if(fileName.empty())
+        return false;
+    if(fileName.front() == '.' || fileName.back() == '.')
+        return false;
+    // Windows silently strips trailing spaces, which would create a mismatch between
+    // the name the user typed and the file actually created on disk.
+    if(fileName.back() == ' ')
+        return false;
+    // On Windows 7 and earlier the device name is the part before the first dot — "nul.ini" is NUL thus forbidden.
+    return !isReservedName(fileName.substr(0, fileName.find('.')));
 }

--- a/libs/common/src/fileFuncs.cpp
+++ b/libs/common/src/fileFuncs.cpp
@@ -44,7 +44,7 @@ std::string makePortableName(const std::string& fileName)
         while(!result.empty() && result.back() == '.')
             result.erase(result.end() - 1);
     }
-    if(!result.empty() && isReservedName(result))
+    if(isReservedName(result))
         result += '_';
     assert(result.empty() || bfs::portable_name(result));
     return result;

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -130,15 +130,19 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
     // Invalid character
     BOOST_TEST(!isValidFileName("save:game"));
 
+    // Invalid UTF-8
+    BOOST_TEST(!isValidFileName("\x80")); // isolated continuation byte
+
     // Length limit (255 Unicode code points)
     BOOST_TEST(isValidFileName(std::string(255, 'a')));
     BOOST_TEST(!isValidFileName(std::string(256, 'a')));
 
-    // é (U+00E9): 2 UTF-8 bytes but 1 code point - verify length is counted in code points, not bytes.
+    // é (U+00E9): 2 UTF-8 bytes — verify length is counted in bytes, covering Linux (255 bytes) and Windows (255 UTF-16
+    // units).
     const std::string eacute = "\xC3\xA9";
-    std::string e256;
-    for(int i = 0; i < 256; ++i)
-        e256 += eacute;
-    BOOST_TEST(isValidFileName(e256.substr(0, e256.size() - eacute.size()))); // 255 code points, 510 bytes
-    BOOST_TEST(!isValidFileName(e256));                                       // 256 code points, 512 bytes
+    std::string e128;
+    for(int i = 0; i < 128; ++i)
+        e128 += eacute;
+    BOOST_TEST(isValidFileName(e128.substr(0, e128.size() - eacute.size()))); // 127 code points, 254 bytes
+    BOOST_TEST(!isValidFileName(e128));                                       // 128 code points, 256 bytes
 }

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -64,18 +64,39 @@ BOOST_AUTO_TEST_CASE(ValidFileNameChar)
 {
     // Allowed
     BOOST_TEST(isValidFileNameChar('a'));
+    BOOST_TEST(isValidFileNameChar('Z'));
+    BOOST_TEST(isValidFileNameChar('5'));
     BOOST_TEST(isValidFileNameChar(' '));
+    BOOST_TEST(isValidFileNameChar('.'));
+    BOOST_TEST(isValidFileNameChar('_'));
+    BOOST_TEST(isValidFileNameChar('-'));
+    BOOST_TEST(isValidFileNameChar('('));
+    BOOST_TEST(isValidFileNameChar(']'));
     BOOST_TEST(isValidFileNameChar(U'\u00E9')); // non-ASCII Unicode
 
     // Rejected — Windows-forbidden
+    BOOST_TEST(!isValidFileNameChar('<'));
+    BOOST_TEST(!isValidFileNameChar('>'));
     BOOST_TEST(!isValidFileNameChar(':'));
-    // Rejected — control character
+    BOOST_TEST(!isValidFileNameChar('"'));
+    BOOST_TEST(!isValidFileNameChar('/'));
+    BOOST_TEST(!isValidFileNameChar('\\'));
+    BOOST_TEST(!isValidFileNameChar('|'));
+    BOOST_TEST(!isValidFileNameChar('?'));
+    BOOST_TEST(!isValidFileNameChar('*'));
+    // Rejected — control characters
     BOOST_TEST(!isValidFileNameChar('\0'));
+    BOOST_TEST(!isValidFileNameChar('\n'));
+    BOOST_TEST(!isValidFileNameChar(0x1F));
 }
 
 BOOST_AUTO_TEST_CASE(ValidFileName)
 {
-    BOOST_TEST(isValidFileName("my save"));
+    BOOST_TEST(isValidFileName("abc"));
+    BOOST_TEST(isValidFileName("Brick  economy  test"));
+    BOOST_TEST(isValidFileName("DevMap (Auto-Save)"));
+    BOOST_TEST(isValidFileName("save_01"));
+    BOOST_TEST(isValidFileName("my save.sav"));
 
     // Empty
     BOOST_TEST(!isValidFileName(""));
@@ -83,6 +104,9 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
     // Reserved name (case-insensitive)
     BOOST_TEST(!isValidFileName("con"));
     BOOST_TEST(!isValidFileName("CON"));
+    BOOST_TEST(!isValidFileName("nul"));
+    BOOST_TEST(!isValidFileName("NUL"));
+    BOOST_TEST(!isValidFileName("Lpt0"));
 
     // Non-reserved look-alike
     BOOST_TEST(isValidFileName("null"));
@@ -99,6 +123,9 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
 
     // Reserved base name with extension (Windows 7 compat)
     BOOST_TEST(!isValidFileName("nul.ini"));
+    BOOST_TEST(!isValidFileName("NUL.ini"));
+    BOOST_TEST(!isValidFileName("nul.txt"));
+    BOOST_TEST(!isValidFileName("com0.txt"));
 
     // Invalid character
     BOOST_TEST(!isValidFileName("save:game"));

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -86,6 +86,7 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
 
     // Non-reserved look-alike
     BOOST_TEST(isValidFileName("null"));
+    BOOST_TEST(isValidFileName("null.ini"));
 
     // Leading/trailing dots
     BOOST_TEST(!isValidFileName(".hidden"));

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -90,6 +90,8 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
     // Leading/trailing dots
     BOOST_TEST(!isValidFileName(".hidden"));
     BOOST_TEST(!isValidFileName("trail."));
+    BOOST_TEST(!isValidFileName("."));
+    BOOST_TEST(!isValidFileName(".."));
 
     // Trailing space
     BOOST_TEST(!isValidFileName("trail "));

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -129,4 +129,16 @@ BOOST_AUTO_TEST_CASE(ValidFileName)
 
     // Invalid character
     BOOST_TEST(!isValidFileName("save:game"));
+
+    // Length limit (255 Unicode code points)
+    BOOST_TEST(isValidFileName(std::string(255, 'a')));
+    BOOST_TEST(!isValidFileName(std::string(256, 'a')));
+
+    // é (U+00E9): 2 UTF-8 bytes but 1 code point - verify length is counted in code points, not bytes.
+    const std::string eacute = "\xC3\xA9";
+    std::string e256;
+    for(int i = 0; i < 256; ++i)
+        e256 += eacute;
+    BOOST_TEST(isValidFileName(e256.substr(0, e256.size() - eacute.size()))); // 255 code points, 510 bytes
+    BOOST_TEST(!isValidFileName(e256));                                       // 256 code points, 512 bytes
 }

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005 - 2021 Settlers Freaks (sf-team at siedler25.org)
+// Copyright (C) 2005 - 2026 Settlers Freaks (sf-team at siedler25.org)
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -20,6 +20,21 @@ BOOST_AUTO_TEST_CASE(PortableName)
     BOOST_TEST(makePortableName("~abc") == "_abc");
     BOOST_TEST(makePortableName("abc ") == "abc_");
     BOOST_TEST(makePortableName("abc.") == "abc");
+
+    // Reserved names get _ appended
+    BOOST_TEST(makePortableName("con") == "con_");
+    BOOST_TEST(makePortableName("NUL") == "NUL_");
+    BOOST_TEST(makePortableName("com1") == "com1_");
+    BOOST_TEST(makePortableName("lpt9") == "lpt9_");
+    BOOST_TEST(makePortableName("com0") == "com0_");
+    BOOST_TEST(makePortableName("lpt0") == "lpt0_");
+    BOOST_TEST(makePortableName("prn") == "prn_");
+    BOOST_TEST(makePortableName("aux") == "aux_");
+    // Non-reserved names are unchanged
+    BOOST_TEST(makePortableName("null") == "null");
+    BOOST_TEST(makePortableName("console") == "console");
+    BOOST_TEST(makePortableName("com10") == "com10");
+    BOOST_TEST(makePortableName("lpt10") == "lpt10");
 }
 
 BOOST_AUTO_TEST_CASE(PortableFileName)
@@ -43,4 +58,86 @@ BOOST_AUTO_TEST_CASE(PortableDirName)
     BOOST_TEST(makePortableDirName("file.ex1.ex2.ex3") == "fileex1ex2ex3");
     BOOST_TEST(makePortableDirName("file.extLONG") == "fileextLONG");
     BOOST_TEST(makePortableDirName("file....") == "file");
+}
+
+BOOST_AUTO_TEST_CASE(ValidFileNameChar)
+{
+    // Allowed
+    BOOST_TEST(isValidFileNameChar('a'));
+    BOOST_TEST(isValidFileNameChar('Z'));
+    BOOST_TEST(isValidFileNameChar('5'));
+    BOOST_TEST(isValidFileNameChar(' '));
+    BOOST_TEST(isValidFileNameChar('.'));
+    BOOST_TEST(isValidFileNameChar('_'));
+    BOOST_TEST(isValidFileNameChar('-'));
+    BOOST_TEST(isValidFileNameChar('('));
+    BOOST_TEST(isValidFileNameChar(')'));
+    BOOST_TEST(isValidFileNameChar('['));
+    BOOST_TEST(isValidFileNameChar(']'));
+    BOOST_TEST(isValidFileNameChar(U'\u00E9')); // U+00E9 e with acute
+
+    // Rejected — Windows-forbidden
+    BOOST_TEST(!isValidFileNameChar('<'));
+    BOOST_TEST(!isValidFileNameChar('>'));
+    BOOST_TEST(!isValidFileNameChar(':'));
+    BOOST_TEST(!isValidFileNameChar('"'));
+    BOOST_TEST(!isValidFileNameChar('/'));
+    BOOST_TEST(!isValidFileNameChar('\\'));
+    BOOST_TEST(!isValidFileNameChar('|'));
+    BOOST_TEST(!isValidFileNameChar('?'));
+    BOOST_TEST(!isValidFileNameChar('*'));
+    // Rejected — control characters
+    BOOST_TEST(!isValidFileNameChar('\0'));
+    BOOST_TEST(!isValidFileNameChar('\n'));
+    BOOST_TEST(!isValidFileNameChar(0x1F));
+}
+
+BOOST_AUTO_TEST_CASE(ValidFileName)
+{
+    // Valid names
+    BOOST_TEST(isValidFileName("my save"));
+    BOOST_TEST(isValidFileName("Brick  economy  test"));
+    BOOST_TEST(isValidFileName("DevMap (Auto-Save)"));
+    BOOST_TEST(isValidFileName("save_01"));
+    BOOST_TEST(isValidFileName("abc"));
+
+    // Empty
+    BOOST_TEST(!isValidFileName(""));
+
+    // Reserved names (case-insensitive)
+    BOOST_TEST(!isValidFileName("con"));
+    BOOST_TEST(!isValidFileName("CON"));
+    BOOST_TEST(!isValidFileName("nul"));
+    BOOST_TEST(!isValidFileName("NUL"));
+    BOOST_TEST(!isValidFileName("com1"));
+    BOOST_TEST(!isValidFileName("COM9"));
+    BOOST_TEST(!isValidFileName("com0"));
+    BOOST_TEST(!isValidFileName("lpt0"));
+    BOOST_TEST(!isValidFileName("lpt9"));
+    BOOST_TEST(!isValidFileName("prn"));
+    BOOST_TEST(!isValidFileName("aux"));
+
+    // Non-reserved names that look similar
+    BOOST_TEST(isValidFileName("null"));
+    BOOST_TEST(isValidFileName("console"));
+    BOOST_TEST(isValidFileName("com10"));
+    BOOST_TEST(isValidFileName("lpt10"));
+
+    // Leading/trailing dots
+    BOOST_TEST(!isValidFileName(".hidden"));
+    BOOST_TEST(!isValidFileName("trail."));
+
+    // Trailing space (Windows silently strips it, causing name mismatch)
+    BOOST_TEST(!isValidFileName("trail "));
+
+    // Reserved base names with extensions are also rejected (Windows 7 compatibility)
+    BOOST_TEST(!isValidFileName("nul.ini"));
+    BOOST_TEST(!isValidFileName("NUL.ini"));
+    BOOST_TEST(!isValidFileName("nul.txt"));
+    BOOST_TEST(!isValidFileName("com0.txt"));
+    BOOST_TEST(!isValidFileName("lpt1.bak"));
+    // Non-reserved names with extensions or dots in the middle are fine
+    BOOST_TEST(isValidFileName("null.ini"));
+    BOOST_TEST(isValidFileName("my.save"));
+    BOOST_TEST(isValidFileName("my save"));
 }

--- a/tests/testFilefuncs.cpp
+++ b/tests/testFilefuncs.cpp
@@ -64,80 +64,39 @@ BOOST_AUTO_TEST_CASE(ValidFileNameChar)
 {
     // Allowed
     BOOST_TEST(isValidFileNameChar('a'));
-    BOOST_TEST(isValidFileNameChar('Z'));
-    BOOST_TEST(isValidFileNameChar('5'));
     BOOST_TEST(isValidFileNameChar(' '));
-    BOOST_TEST(isValidFileNameChar('.'));
-    BOOST_TEST(isValidFileNameChar('_'));
-    BOOST_TEST(isValidFileNameChar('-'));
-    BOOST_TEST(isValidFileNameChar('('));
-    BOOST_TEST(isValidFileNameChar(')'));
-    BOOST_TEST(isValidFileNameChar('['));
-    BOOST_TEST(isValidFileNameChar(']'));
-    BOOST_TEST(isValidFileNameChar(U'\u00E9')); // U+00E9 e with acute
+    BOOST_TEST(isValidFileNameChar(U'\u00E9')); // non-ASCII Unicode
 
     // Rejected — Windows-forbidden
-    BOOST_TEST(!isValidFileNameChar('<'));
-    BOOST_TEST(!isValidFileNameChar('>'));
     BOOST_TEST(!isValidFileNameChar(':'));
-    BOOST_TEST(!isValidFileNameChar('"'));
-    BOOST_TEST(!isValidFileNameChar('/'));
-    BOOST_TEST(!isValidFileNameChar('\\'));
-    BOOST_TEST(!isValidFileNameChar('|'));
-    BOOST_TEST(!isValidFileNameChar('?'));
-    BOOST_TEST(!isValidFileNameChar('*'));
-    // Rejected — control characters
+    // Rejected — control character
     BOOST_TEST(!isValidFileNameChar('\0'));
-    BOOST_TEST(!isValidFileNameChar('\n'));
-    BOOST_TEST(!isValidFileNameChar(0x1F));
 }
 
 BOOST_AUTO_TEST_CASE(ValidFileName)
 {
-    // Valid names
     BOOST_TEST(isValidFileName("my save"));
-    BOOST_TEST(isValidFileName("Brick  economy  test"));
-    BOOST_TEST(isValidFileName("DevMap (Auto-Save)"));
-    BOOST_TEST(isValidFileName("save_01"));
-    BOOST_TEST(isValidFileName("abc"));
 
     // Empty
     BOOST_TEST(!isValidFileName(""));
 
-    // Reserved names (case-insensitive)
+    // Reserved name (case-insensitive)
     BOOST_TEST(!isValidFileName("con"));
     BOOST_TEST(!isValidFileName("CON"));
-    BOOST_TEST(!isValidFileName("nul"));
-    BOOST_TEST(!isValidFileName("NUL"));
-    BOOST_TEST(!isValidFileName("com1"));
-    BOOST_TEST(!isValidFileName("COM9"));
-    BOOST_TEST(!isValidFileName("com0"));
-    BOOST_TEST(!isValidFileName("lpt0"));
-    BOOST_TEST(!isValidFileName("lpt9"));
-    BOOST_TEST(!isValidFileName("prn"));
-    BOOST_TEST(!isValidFileName("aux"));
 
-    // Non-reserved names that look similar
+    // Non-reserved look-alike
     BOOST_TEST(isValidFileName("null"));
-    BOOST_TEST(isValidFileName("console"));
-    BOOST_TEST(isValidFileName("com10"));
-    BOOST_TEST(isValidFileName("lpt10"));
 
     // Leading/trailing dots
     BOOST_TEST(!isValidFileName(".hidden"));
     BOOST_TEST(!isValidFileName("trail."));
 
-    // Trailing space (Windows silently strips it, causing name mismatch)
+    // Trailing space
     BOOST_TEST(!isValidFileName("trail "));
 
-    // Reserved base names with extensions are also rejected (Windows 7 compatibility)
+    // Reserved base name with extension (Windows 7 compat)
     BOOST_TEST(!isValidFileName("nul.ini"));
-    BOOST_TEST(!isValidFileName("NUL.ini"));
-    BOOST_TEST(!isValidFileName("nul.txt"));
-    BOOST_TEST(!isValidFileName("com0.txt"));
-    BOOST_TEST(!isValidFileName("lpt1.bak"));
-    // Non-reserved names with extensions or dots in the middle are fine
-    BOOST_TEST(isValidFileName("null.ini"));
-    BOOST_TEST(isValidFileName("my.save"));
-    BOOST_TEST(isValidFileName("my save"));
+
+    // Invalid character
+    BOOST_TEST(!isValidFileName("save:game"));
 }


### PR DESCRIPTION
## Summary

Adds Windows reserved device name support to `makePortableName` and introduces two new predicates (`isValidFileNameChar`, `isValidFileName`) for validating user-provided filenames.

## Motivation

These utilities are needed in s25client to validate user-provided filenames in save file dialogs and similar text input controls, where both real-time character filtering and save-time structural validation are required.

## Note

`makePortableFileName` (and by extension `makePortableName`) is intended for **programmatic** filename creation - it silently and automatically replaces invalid characters without user involvement.

For **user-provided** filenames - such as save games and the incoming addon presets feature ([s25client PR #1951](https://github.com/Return-To-The-Roots/s25client/pull/1951)) - the intended approach is different: invalid characters will be suppressed at the `ctrlEdit` input level using `isValidFileNameChar`, and `isValidFileName` will perform a final structural check on save. If validation fails, the user receives a general message asking them to correct the name before saving. There is no automatic character replacement and no per-reason error detail - both would complicate the implementation, and silent replacement in particular would create an inconsistent experience where the saved filename silently differs from what the user typed.

## Changes

### `makePortableName`

Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM0`–`COM9`, `LPT0`–`LPT9`) were previously passed through unchanged when they already satisfied `bfs::portable_name`. This caused a subtle bug where e.g. `"nul"` was returned as-is despite being unusable as a filename on Windows. The fix appends `'_'` to any reserved name.

### `isValidFileNameChar(char32_t)`

New predicate for real-time filtering of user-typed filename characters. Rejects control characters and characters forbidden on Windows (`< > : " / \ | ? *`), which is the most restrictive set across all supported platforms.

### `isValidFileName(const std::string&)`

New structural validator for complete user-provided filenames. Rejects:

- Empty names
- Windows reserved device names - On Windows 7 and earlier, the device name is determined by the part before the first dot - making "nul.ini" equivalent to NUL and therefore invalid. Windows 10/11 relaxed this so that only bare names like "nul" are restricted, while "nul.ini" is a valid regular file. For cross-version portability, `fileName` is checked against the segment before the first dot, so "nul.ini" is also rejected
- Names starting or ending with a dot
- Names with a trailing space (Windows silently strips it, causing a mismatch between the displayed and actual filename; trimming before calling is left to the caller)

### Comment corrections

The existing doc comments on `makePortableName`, `makePortableFileName` and `makePortableDirName` incorrectly stated that invalid characters were removed, when they are in fact replaced with _. Comments have been corrected to accurately describe the sanitization behavior.

### Tests

Added test cases covering reserved device name handling in `makePortableName` (bare names such as "con", "NUL", "com0") and the new `isValidFileNameChar` and `isValidFileName` functions.
